### PR TITLE
Issue #6 support revoke function

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ $provider = new \Calcinai\OAuth2\Client\Provider\Xero([
  ]);
  ```
  
+Scopes are cumulative, meaning they will remain granted to the app for the user
+until authorisation is revoked. Every new authorisation flow can add new scopes
+that may not have been granted previously, and they will persist.
+ 
 ## Refreshing a token
 
 ```php
@@ -88,6 +92,20 @@ $newAccessToken = $provider->getAccessToken('refresh_token', [
 ]);
 ```
 
+## Revoking a token
+
+A token, or authorisation, for a user can be revoked completely.
+This can only be done through the API (a user cannot revoke their grants
+through the Xero UI, except by deleting their account).
+
+Revoking a token will result in all granted scopes, and all connected tenants
+being removed from the app for the authorising user.
+
+The refresh token is needed to revoke a grant:
+
+```php
+$provider->revoke($refreshToken);
+```
 
 ## Testing
 

--- a/src/Provider/Xero.php
+++ b/src/Provider/Xero.php
@@ -146,12 +146,11 @@ class Xero extends AbstractProvider
      * Returns the URL for requesting the resource owner's details.
      *
      * @param AccessToken $token
-     *
      * @return string
      */
     public function getResourceOwnerDetailsUrl(AccessToken $token)
     {
-        //This does not exist as it comes down in the JWT
+        // This does not exist as it comes down in the JWT
         return '';
     }
 
@@ -163,7 +162,6 @@ class Xero extends AbstractProvider
     {
         return XeroResourceOwner::fromJWT($token->getValues()['id_token']);
     }
-
 
     /**
      * Checks a provider response for errors.

--- a/src/XeroResourceOwner.php
+++ b/src/XeroResourceOwner.php
@@ -38,12 +38,38 @@ class XeroResourceOwner
     public $family_name;
 
     /**
+     * @var string the unique user ID, different to Xero user ID
+     */
+    public $sub;
+
+    /**
+     * @var int details expirey time
+     */
+    public $exp;
+
+    /**
+     * @var int the time the authorisation was first granted for this token
+     */
+    public $auth_time;
+
+    /**
+     * @var int token issued at time; last authentication flow time
+     */
+    public $iat;
+
+    /**
+     * @var string
+     */
+    public $aud;
+
+    /**
      * @param $token
      * @return static
      */
     public static function fromJWT($token)
     {
         list($header, $body, $crypto) = explode('.', $token);
+
         //This needs to be done manually as we don't get a signed JWT
         $decoded = JWT::jsonDecode(JWT::urlsafeB64Decode($body));
 
@@ -54,7 +80,27 @@ class XeroResourceOwner
         $self->email = $decoded->email;
         $self->given_name = $decoded->given_name;
         $self->family_name = $decoded->family_name;
+        $self->sub = $decoded->sub;
+        $self->exp = $decoded->exp;
+        $self->auth_time = $decoded->auth_time;
+        $self->iat = $decoded->iat;
+        $self->aud = $decoded->aud;
 
         return $self;
+    }
+
+    /**
+     * Provide camelCase access to the underlying properties.
+     *
+     * @param $name
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        $snakeCase = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $name));
+
+        if (property_exists($this, $snakeCase)) {
+            return $this->$snakeCase;
+        }
     }
 }

--- a/src/XeroResourceOwner.php
+++ b/src/XeroResourceOwner.php
@@ -43,7 +43,7 @@ class XeroResourceOwner
     public $sub;
 
     /**
-     * @var int details expirey time
+     * @var int details expiry time
      */
     public $exp;
 
@@ -70,7 +70,7 @@ class XeroResourceOwner
     {
         list($header, $body, $crypto) = explode('.', $token);
 
-        //This needs to be done manually as we don't get a signed JWT
+        // This needs to be done manually as we don't get a signed JWT
         $decoded = JWT::jsonDecode(JWT::urlsafeB64Decode($body));
 
         $self = new static();
@@ -87,20 +87,5 @@ class XeroResourceOwner
         $self->aud = $decoded->aud;
 
         return $self;
-    }
-
-    /**
-     * Provide camelCase access to the underlying properties.
-     *
-     * @param $name
-     * @return mixed
-     */
-    public function __get($name)
-    {
-        $snakeCase = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $name));
-
-        if (property_exists($this, $snakeCase)) {
-            return $this->$snakeCase;
-        }
     }
 }

--- a/src/XeroTenant.php
+++ b/src/XeroTenant.php
@@ -59,7 +59,7 @@ class XeroTenant
         $self->tenantType = $data['tenantType'];
         $self->tenantName = $data['tenantName'];
         $self->createdDateUtc = new \DateTime($data['createdDateUtc']);
-        $self->updatedDateUtc = $self->updatedDateUtc ? new \DateTime($data['updatedDateUtc']) : null;
+        $self->updatedDateUtc = new \DateTime($data['updatedDateUtc']);
 
         return $self;
     }


### PR DESCRIPTION
Provides a function to revoke a token completely, along with all granted scopes.

This endpoint uses Basic auth and requires the refresh token to identify the authorisation being revoked.