### PR TITLE
Alter default scope separator for Xero connect requests

### DIFF
--- a/src/Provider/Xero.php
+++ b/src/Provider/Xero.php
@@ -146,6 +146,17 @@ class Xero extends AbstractProvider
     }
 
     /**
+     * Returns the string that should be used to separate scopes when building
+     * the URL for requesting an access token.
+     *
+     * @return string Scope separator, defaults to ' '
+     */
+    protected function getScopeSeparator()
+    {
+        return ' ';
+    }
+
+    /**
      * Generates a resource owner object from a successful resource owner
      * details request.
      *


### PR DESCRIPTION
The default oauth league scope separator is a comma, however Xero
requires spaces instead. When passing an array of scopes, the underlying
league code will implode the scope array automatically. But this will be
rejected via Xero due to the comma. Use a space instead.

@see https://github.com/calcinai/oauth2-xero#authorization-code-flow
@see https://developer.xero.com/documentation/oauth2/sign-in

Scopes are the permissions that your app is requesting approval for.
You can pass in a list of scopes separated by a space.