### PR TITLE
Fix XeroTenant: updatedDateUtc always null.

### DIFF
--- a/src/XeroTenant.php
+++ b/src/XeroTenant.php
@@ -59,7 +59,7 @@ class XeroTenant
         $self->tenantType = $data['tenantType'];
         $self->tenantName = $data['tenantName'];
         $self->createdDateUtc = new \DateTime($data['createdDateUtc']);
-        $self->updatedDateUtc = $self->updatedDateUtc ? new \DateTime($data['updatedDateUtc']) : null;
+        $self->updatedDateUtc = isset($data['updatedDateUtc']) ? new \DateTime($data['updatedDateUtc']) : null;
 
         return $self;
     }


### PR DESCRIPTION
Xero orgs updatedDateUtc is aways null making it impossible to guess the current org the user has given access.
This fixes the case when we want to retrieve the last auth xero org as explained here:
https://developer.xero.com/documentation/guides/oauth2/auth-flow/#5-check-the-tenants-youre-authorized-to-access