### PR TITLE
Bump minimal PHP to 7.1 to support nullable types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "league/oauth2-client": "1.*|2.*",
-    "php": ">=5.5.0",
+    "php": ">=7.1.0",
     "firebase/php-jwt": "^5.0"
   },
   "require-dev": {


### PR DESCRIPTION
Linked to https://github.com/calcinai/oauth2-xero/pull/18

Detail: https://www.php.net/manual/en/migration71.new-features.php