### PR TITLE
Update supported versions of firebase/php-jwt package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require": {
     "league/oauth2-client": "1.*|2.*",
     "php": ">=7.1.0",
-    "firebase/php-jwt": "^5.0"
+    "firebase/php-jwt": "^5.0|^6.0"
   },
   "require-dev": {
   },


### PR DESCRIPTION
Have tested the dependency update on PHP 7 & 8.

None of the breaking changes between 5 -> 6 for `firebase/php-jwt` look to affect what `oauth2-xero` is doing so I suggest leaving both versions as supported.